### PR TITLE
Fix compilation when using Xcode 11.5

### DIFF
--- a/Sources/PureSwiftUI/Extensions/SwiftUI/Views/Modifiers/ContainerStyling/View+ClipShapes.swift
+++ b/Sources/PureSwiftUI/Extensions/SwiftUI/Views/Modifiers/ContainerStyling/View+ClipShapes.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-private struct ClipShapeWithNoFillViewModifier<S: Shape>: ViewModifier {
+struct ClipShapeWithNoFillViewModifier<S: Shape>: ViewModifier {
     
     let shape: S
     let constrainGestures: Bool
@@ -20,7 +20,7 @@ private struct ClipShapeWithNoFillViewModifier<S: Shape>: ViewModifier {
     }
 }
 
-private struct ClipShapeWithFillViewModifier<S: Shape, SS: ShapeStyle>: ViewModifier {
+struct ClipShapeWithFillViewModifier<S: Shape, SS: ShapeStyle>: ViewModifier {
     
     let shape: S
     let fill: SS


### PR DESCRIPTION
Fixes the following errors when building in DEBUG using Xcode 11.5

Global is external, but doesn't have external or weak linkage!
%swift.metadata_response.108 (i64, %swift.type.107*, i8**)* @"$s11PureSwiftUI31ClipShapeWithNoFillViewModifier33_AE1A7A97ECBCA298A14566642270AD8BLLVMa”

Global is external, but doesn't have external or weak linkage!
%swift.metadata_response.108 (i64, i8**)* @"$s11PureSwiftUI29ClipShapeWithFillViewModifier33_AE1A7A97ECBCA298A14566642270AD8BLLVMa"